### PR TITLE
[HOTT-356] Supports query params in uktt gem

### DIFF
--- a/lib/uktt.rb
+++ b/lib/uktt.rb
@@ -37,7 +37,8 @@ module Uktt
               version: Uktt::Http.spec_version, 
               debug: false,
               format: 'ostruct',
-              currency: PARENT_CURRENCY
+              currency: PARENT_CURRENCY,
+              query: {},
             }
 
   @valid_config_keys = @config.keys

--- a/lib/uktt/http.rb
+++ b/lib/uktt/http.rb
@@ -17,10 +17,23 @@ module Uktt
 
     def retrieve(resource, format = 'ostruct')
       full_url = File.join(@host, 'api', @version, resource)
+      full_url = "#{full_url}#{query}"
       headers  = { 'Content-Type' => 'application/json' }
       response = @conn.get(full_url, {}, headers)
 
       Parser.new(response.body, format).parse
+    end
+
+    private
+
+    def query
+      return "" if Uktt.config[:query].empty?
+
+      query = Uktt.config[:query].map do |key, value|
+        "#{key}=#{value}"
+      end
+
+      "?#{query.join(',')}"
     end
 
     class << self

--- a/lib/uktt/http.rb
+++ b/lib/uktt/http.rb
@@ -27,7 +27,7 @@ module Uktt
     private
 
     def query
-      return "" if Uktt.config[:query].empty?
+      return '' if Uktt.config[:query].empty?
 
       query = Uktt.config[:query].map do |key, value|
         "#{key}=#{value}"

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -49,5 +49,20 @@ RSpec.describe Uktt::Http do
         expect(conn).to have_received(:get).with(expected_url, expected_body, expected_headers)
       end
     end
+
+    context 'when a query param is specified in the config' do
+      before do
+        Uktt.configure(format: 'jsonapi', version: 'v2', query: { 'filter[geographical_area_id]' => 'RO' })
+      end
+
+      let(:host) { 'http://localhost' }
+      let(:expected_url)  { 'http://localhost/api/v2/commodities/1234567890?filter[geographical_area_id]=RO' }
+
+      it 'uses the correct full url with the query constructed' do
+        client.retrieve('commodities/1234567890')
+
+        expect(conn).to have_received(:get).with(expected_url, expected_body, expected_headers)
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
-require 'uktt'
 require 'json-schema'
+require 'pry'
+require 'uktt'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/uktt_spec.rb
+++ b/spec/uktt_spec.rb
@@ -7,13 +7,15 @@ RSpec.describe 'UK Trade Tariff gem' do
                host: api_host, 
                version: spec_version,
                debug: false,
-               currency: Uktt::PARENT_CURRENCY}
+               currency: Uktt::PARENT_CURRENCY,
+               query: {}}
 
   new_opts = {host: host,
               version: 'v2',
               format: 'json',
               debug: true,
-              currency: Uktt::PARENT_CURRENCY}
+              currency: Uktt::PARENT_CURRENCY,
+              query: {}}
 
   section_id = '1'
   section_test = Uktt::Section.new(test_opts.merge(section_id: section_id))


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-356

### What?

I have added/removed/altered:

- [x] Adds support for a generic query object that gets serialized as a query param

### Why?

I am doing this because:

- This is needed to pull out measures that are relevant to the duty calculator