### PR TITLE
Replace faraday with native net/http

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,6 @@ PATH
   remote: .
   specs:
     uktt (1.1.0)
-      faraday
-      faraday_middleware
 
 GEM
   remote: https://rubygems.org/
@@ -21,20 +19,12 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.7)
     diff-lcs (1.3)
-    faraday (1.3.0)
-      faraday-net_http (~> 1.0)
-      multipart-post (>= 1.2, < 3)
-      ruby2_keywords
-    faraday-net_http (1.0.1)
-    faraday_middleware (1.0.0)
-      faraday (~> 1.0)
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
     method_source (1.0.0)
     minitest (5.14.3)
-    multipart-post (2.1.1)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
@@ -89,7 +79,6 @@ GEM
     rubocop-rspec (1.42.0)
       rubocop (>= 0.87.0)
     ruby-progressbar (1.11.0)
-    ruby2_keywords (0.0.4)
     thread_safe (0.3.6)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -1,19 +1,28 @@
 require 'uktt'
 
 RSpec.describe Uktt::Http do
-  subject(:client) { described_class.new(host, version, debug, conn, format) }
+  subject(:client) { described_class.new(connection, service, version, format) }
 
+  let(:connection) { double }
+  let(:service) { '' }
   let(:version) { 'v2' }
-  let(:debug) { false }
-  let(:conn) { double }
-  let(:response) { double }
-  let(:parser) { double(parse: {}) }
-  let(:host) { 'http://localhost' }
   let(:format) { 'ostruct' }
+
+  let(:response) { Net::HTTPSuccess.new(nil, body, nil) }
+  let(:body) { '{}' }
+  let(:parser) { double(parse: {}) }
+
+  describe '.build' do
+    let(:host) { 'http://localhost' }
+
+    it 'builds a Uktt::Http client instance' do
+      expect(described_class.build(host, version, format)).to be_a(described_class)
+    end
+  end
 
   describe '#retrieve' do
     before do
-      allow(conn).to receive(:get).and_return(response)
+      allow(connection).to receive(:request).and_return(response)
       allow(response).to receive(:body).and_return('{}')
       allow(Uktt::Parser).to receive(:new).and_return(parser)
     end
@@ -28,36 +37,47 @@ RSpec.describe Uktt::Http do
     end
 
     context 'when the host includes xi in the path' do
-      let(:host) { 'http://localhost/xi' }
-      let(:expected_url) { 'http://localhost/xi/api/v2/commodities/1234567890' }
+      let(:host) { 'http://localhost' }
+      let(:service) { '/xi' }
+      let(:expected_path) { '/xi/api/v2/commodities/1234567890' }
 
-      it 'uses the correct full url' do
+      it 'uses the correct full path' do
         client.retrieve('commodities/1234567890')
 
-        expect(conn).to have_received(:get).with(expected_url, expected_body, expected_headers)
+        expect(connection).to have_received(:request) do |request|
+          expect(request.path).to eq(expected_path)
+          expect(request['Content-Type']).to eq('application/json')
+        end
       end
     end
 
     context 'when the host does not include xi in the path' do
       let(:host) { 'http://localhost' }
-      let(:expected_url) { 'http://localhost/api/v2/commodities/1234567890' }
+      let(:service) { '' }
+      let(:expected_path) { '/api/v2/commodities/1234567890' }
 
       it 'uses the correct full url' do
         client.retrieve('commodities/1234567890')
 
-        expect(conn).to have_received(:get).with(expected_url, expected_body, expected_headers)
+        expect(connection).to have_received(:request) do |request|
+          expect(request.path).to eq(expected_path)
+          expect(request['Content-Type']).to eq('application/json')
+        end
       end
     end
 
-    context 'when a query param is specified in the config' do
+    context 'when a query is passed request' do
       let(:query) { { 'filter[geographical_area_id]' => 'RO' } }
       let(:host) { 'http://localhost' }
-      let(:expected_url) { 'http://localhost/api/v2/commodities/1234567890?filter[geographical_area_id]=RO' }
+      let(:expected_path) { '/api/v2/commodities/1234567890?filter[geographical_area_id]=RO' }
 
       it 'uses the correct full url with the query constructed' do
         client.retrieve('commodities/1234567890', query)
 
-        expect(conn).to have_received(:get).with(expected_url, expected_body, expected_headers)
+        expect(connection).to have_received(:request) do |request|
+          expect(request.path).to eq(expected_path)
+          expect(request['Content-Type']).to eq('application/json')
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,12 +3,22 @@ require 'json-schema'
 require 'pry'
 require 'uktt'
 
+RSpec.shared_context :http_resources do
+  let(:http) { Uktt::Http.build(host, version, format) }
+
+  let(:host) { 'https://dev.trade-tariff.service.gov.uk' }
+  let(:version) { 'v2' }
+  let(:format) { 'jsonapi' }
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+
+  config.include_context :http_resources, :http
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/uktt/chapter_spec.rb
+++ b/spec/uktt/chapter_spec.rb
@@ -1,21 +1,5 @@
-RSpec.describe Uktt::Chapter do
+RSpec.describe Uktt::Chapter, :http do
   subject(:chapter) { described_class.new(http) }
-
-  let(:http) do
-    Uktt::Http.new(
-      host,
-      version,
-      debug,
-      conn,
-      format,
-    )
-  end
-
-  let(:host) { 'https://dev.trade-tariff.service.gov.uk' }
-  let(:version) { 'v2' }
-  let(:debug) { false }
-  let(:conn) { nil }
-  let(:format) { 'jsonapi' }
 
   let(:chapter_id) { '01' }
 

--- a/spec/uktt/commodity_spec.rb
+++ b/spec/uktt/commodity_spec.rb
@@ -1,21 +1,5 @@
-RSpec.describe Uktt::Commodity do
+RSpec.describe Uktt::Commodity, :http do
   subject(:commodity) { described_class.new(http) }
-
-  let(:http) do
-    Uktt::Http.new(
-      host,
-      version,
-      debug,
-      conn,
-      format,
-    )
-  end
-
-  let(:host) { 'https://dev.trade-tariff.service.gov.uk' }
-  let(:version) { 'v2' }
-  let(:debug) { false }
-  let(:conn) { nil }
-  let(:format) { 'jsonapi' }
 
   let(:commodity_id) { '0101210000' }
 

--- a/spec/uktt/heading_spec.rb
+++ b/spec/uktt/heading_spec.rb
@@ -1,21 +1,5 @@
-RSpec.describe Uktt::Heading do
+RSpec.describe Uktt::Heading, :http do
   subject(:heading) { described_class.new(http) }
-
-  let(:http) do
-    Uktt::Http.new(
-      host,
-      version,
-      debug,
-      conn,
-      format,
-    )
-  end
-
-  let(:host) { 'https://dev.trade-tariff.service.gov.uk' }
-  let(:version) { 'v2' }
-  let(:debug) { false }
-  let(:conn) { nil }
-  let(:format) { 'jsonapi' }
 
   let(:heading_id) { '0101' }
 

--- a/spec/uktt/quota_spec.rb
+++ b/spec/uktt/quota_spec.rb
@@ -1,21 +1,5 @@
-RSpec.describe Uktt::Quota do
+RSpec.describe Uktt::Quota, :http do
   subject(:quota) { described_class.new(http) }
-
-  let(:http) do
-    Uktt::Http.new(
-      host,
-      version,
-      debug,
-      conn,
-      format,
-    )
-  end
-
-  let(:host) { 'https://dev.trade-tariff.service.gov.uk' }
-  let(:version) { 'v2' }
-  let(:debug) { false }
-  let(:conn) { nil }
-  let(:format) { 'jsonapi' }
 
   describe '#search' do
     let(:params) do

--- a/spec/uktt/section_spec.rb
+++ b/spec/uktt/section_spec.rb
@@ -1,21 +1,5 @@
-RSpec.describe Uktt::Section do
+RSpec.describe Uktt::Section, :http do
   subject(:section) { described_class.new(http) }
-
-  let(:http) do
-    Uktt::Http.new(
-      host,
-      version,
-      debug,
-      conn,
-      format,
-    )
-  end
-
-  let(:host) { 'https://dev.trade-tariff.service.gov.uk' }
-  let(:version) { 'v2' }
-  let(:debug) { false }
-  let(:conn) { nil }
-  let(:format) { 'jsonapi' }
 
   let(:section_id) { '1' }
 

--- a/uktt.gemspec
+++ b/uktt.gemspec
@@ -33,9 +33,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.add_dependency 'faraday'
-  spec.add_dependency 'faraday_middleware'
-
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'json-schema'
   spec.add_development_dependency 'pry-byebug'


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds shared context for http in tests
- [x] Updates to using net/http instead of Faraday plus the middleware

### Why?

I am doing this because:

- Faraday is bloated for our needs, really. We're only doing simple gets with redirects
