### PR TITLE
Construct a common implementation for retrieve and retrieve_all

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uktt (1.1.0)
+    uktt (1.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/uktt/resources/base.rb
+++ b/lib/uktt/resources/base.rb
@@ -5,8 +5,12 @@ class Base
     @http = http
   end
 
-  def retrieve
-    raise NotImplementedError
+  def retrieve(id, query_config = {})
+    fetch "#{self.class::RESOURCE_PATH}/#{id}.json", query_config
+  end
+
+  def retrieve_all(query_config = {})
+    fetch "#{self.class::RESOURCE_PATH}.json", query_config
   end
 
   protected

--- a/lib/uktt/resources/chapter.rb
+++ b/lib/uktt/resources/chapter.rb
@@ -3,16 +3,6 @@ module Uktt
   class Chapter < Base
     RESOURCE_PATH = 'chapters'.freeze
 
-    attr_accessor :chapter_id
-
-    def retrieve(chapter_id)
-      fetch "#{RESOURCE_PATH}/#{chapter_id}.json"
-    end
-
-    def retrieve_all
-      fetch "#{RESOURCE_PATH}.json"
-    end
-
     def goods_nomenclatures(chapter_id)
       fetch "goods_nomenclatures/chapter/#{chapter_id}.json"
     end

--- a/lib/uktt/resources/commodity.rb
+++ b/lib/uktt/resources/commodity.rb
@@ -3,10 +3,6 @@ module Uktt
   class Commodity < Base
     RESOURCE_PATH = 'commodities'.freeze
 
-    def retrieve(commodity_id)
-      fetch "#{RESOURCE_PATH}/#{commodity_id}.json"
-    end
-
     def changes(commodity_id)
       fetch "#{RESOURCE_PATH}/#{commodity_id}/changes.json"
     end

--- a/lib/uktt/resources/country.rb
+++ b/lib/uktt/resources/country.rb
@@ -2,8 +2,8 @@ module Uktt
   class Country < Base
     RESOURCE_PATH = 'geographical_areas'.freeze
 
-    def retrieve
-      fetch "#{RESOURCE_PATH}/countries"
+    def retrieve_all(query_config = {})
+      fetch "#{RESOURCE_PATH}/countries.json", query_config
     end
   end
 end

--- a/lib/uktt/resources/exchange_rate.rb
+++ b/lib/uktt/resources/exchange_rate.rb
@@ -1,9 +1,5 @@
 module Uktt
   class ExchangeRate < Base
     RESOURCE_PATH = 'exchange_rates'.freeze
-
-    def retrieve
-      fetch RESOURCE_PATH
-    end
   end
 end

--- a/lib/uktt/resources/geographical_area.rb
+++ b/lib/uktt/resources/geographical_area.rb
@@ -1,9 +1,5 @@
 module Uktt
   class GeographicalArea < Base
     RESOURCE_PATH = 'geographical_areas'.freeze
-
-    def retrieve
-      fetch RESOURCE_PATH
-    end
   end
 end

--- a/lib/uktt/resources/heading.rb
+++ b/lib/uktt/resources/heading.rb
@@ -3,10 +3,6 @@ module Uktt
   class Heading < Base
     RESOURCE_PATH = 'headings'.freeze
 
-    def retrieve(heading_id)
-      fetch "#{RESOURCE_PATH}/#{heading_id}.json"
-    end
-
     def changes(heading_id)
       fetch "#{RESOURCE_PATH}/#{heading_id}/changes.json"
     end

--- a/lib/uktt/resources/section.rb
+++ b/lib/uktt/resources/section.rb
@@ -2,14 +2,6 @@ module Uktt
   class Section < Base
     RESOURCE_PATH = 'sections'.freeze
 
-    def retrieve(section_id)
-      fetch "#{RESOURCE_PATH}/#{section_id}.json"
-    end
-
-    def retrieve_all
-      fetch "#{RESOURCE_PATH}.json"
-    end
-
     def note(section_id)
       fetch "#{RESOURCE_PATH}/#{section_id}/section_note.json"
     end

--- a/lib/uktt/version.rb
+++ b/lib/uktt/version.rb
@@ -1,3 +1,3 @@
 module Uktt
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/spec/uktt/country_spec.rb
+++ b/spec/uktt/country_spec.rb
@@ -3,11 +3,11 @@ RSpec.describe Uktt::Country do
 
   let(:http) { instance_double('Uktt::Http') }
 
-  describe '#retrieve' do
+  describe '#retrieve_all' do
     it 'performs a retrieve of countries' do
-      allow(http).to receive(:retrieve).with('geographical_areas/countries', {})
+      allow(http).to receive(:retrieve).with('geographical_areas/countries.json', {})
 
-      country.retrieve
+      country.retrieve_all
     end
   end
 end

--- a/spec/uktt/exchange_rate_spec.rb
+++ b/spec/uktt/exchange_rate_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Uktt::ExchangeRate do
   let(:http) { instance_double('Uktt::Http') }
 
   describe '#retrieve' do
-    it 'performs a retrieve of countries' do
-      allow(http).to receive(:retrieve).with('exchange_rates', {})
+    it 'performs a retrieve of exchange_rates' do
+      allow(http).to receive(:retrieve).with('exchange_rates.json', {})
 
-      exchange_rate.retrieve
+      exchange_rate.retrieve_all
     end
   end
 end

--- a/spec/uktt/geographical_area_spec.rb
+++ b/spec/uktt/geographical_area_spec.rb
@@ -3,11 +3,11 @@ RSpec.describe Uktt::GeographicalArea do
 
   let(:http) { instance_double('Uktt::Http') }
 
-  describe '#retrieve' do
+  describe '#retrieve_all' do
     it 'performs a retrieve of geographical_areas' do
-      allow(http).to receive(:retrieve).with('geographical_areas', {})
+      allow(http).to receive(:retrieve).with('geographical_areas.json', {})
 
-      geographical_area.retrieve
+      geographical_area.retrieve_all
     end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

We want to force a common api for our restful resources. To get to this we need to move to a common interface for our resources rather than specific overrides. The exception to this is when we have a non-restful resource (e.g. countries, changes, goods_nomenclature apis, etc)

### Why?

I am doing this because:

- These implementations have the same api and are really duplicating leading to minor variations