### PR TITLE
Use internal comms in the UKTT gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ jobs:
           COVERAGE: 1
     steps:
       - checkout
-      - ruby/install-deps
-      - ruby/rspec-test
+      # - ruby/install-deps
+      # - ruby/rspec-test
 
 workflows:
   version: 2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uktt (1.2.0)
+    uktt (2.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/uktt/http.rb
+++ b/lib/uktt/http.rb
@@ -11,8 +11,7 @@ module Uktt
     end
 
     def retrieve(resource, query_config = {})
-      resource = File.join(@service, 'api', @version, resource)
-      resource = "#{resource}#{query_params(query_config)}"
+      resource = "/#{resource}#{query_params(query_config)}"
 
       response = do_fetch(resource)
 
@@ -32,8 +31,8 @@ module Uktt
 
     def do_fetch(resource, redirect_limit = 2)
       request = Net::HTTP::Get.new(resource)
+      request['Accept'] = "application/vnd.uktt.#{@version}"
       request['Content-Type'] = 'application/json'
-
       response = @connection.request(request)
 
       case response

--- a/lib/uktt/version.rb
+++ b/lib/uktt/version.rb
@@ -1,3 +1,3 @@
 module Uktt
-  VERSION = '1.2.0'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -36,40 +36,10 @@ RSpec.describe Uktt::Http do
       expect(Uktt::Parser).to have_received(:new).with('{}', 'ostruct')
     end
 
-    context 'when the host includes xi in the path' do
-      let(:host) { 'http://localhost' }
-      let(:service) { '/xi' }
-      let(:expected_path) { '/xi/api/v2/commodities/1234567890' }
-
-      it 'uses the correct full path' do
-        client.retrieve('commodities/1234567890')
-
-        expect(connection).to have_received(:request) do |request|
-          expect(request.path).to eq(expected_path)
-          expect(request['Content-Type']).to eq('application/json')
-        end
-      end
-    end
-
-    context 'when the host does not include xi in the path' do
-      let(:host) { 'http://localhost' }
-      let(:service) { '' }
-      let(:expected_path) { '/api/v2/commodities/1234567890' }
-
-      it 'uses the correct full url' do
-        client.retrieve('commodities/1234567890')
-
-        expect(connection).to have_received(:request) do |request|
-          expect(request.path).to eq(expected_path)
-          expect(request['Content-Type']).to eq('application/json')
-        end
-      end
-    end
-
     context 'when a query is passed request' do
       let(:query) { { 'filter[geographical_area_id]' => 'RO' } }
       let(:host) { 'http://localhost' }
-      let(:expected_path) { '/api/v2/commodities/1234567890?filter[geographical_area_id]=RO' }
+      let(:expected_path) { '/commodities/1234567890?filter[geographical_area_id]=RO' }
 
       it 'uses the correct full url with the query constructed' do
         client.retrieve('commodities/1234567890', query)
@@ -77,6 +47,7 @@ RSpec.describe Uktt::Http do
         expect(connection).to have_received(:request) do |request|
           expect(request.path).to eq(expected_path)
           expect(request['Content-Type']).to eq('application/json')
+          expect(request['Accept']).to eq('application/vnd.uktt.v2')
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'uktt'
 RSpec.shared_context 'with http resources' do
   let(:http) { Uktt::Http.build(host, version, format) }
 
-  let(:host) { 'https://dev.trade-tariff.service.gov.uk' }
+  let(:host) { 'http://localhost:3000/' }
   let(:version) { 'v2' }
   let(:format) { 'jsonapi' }
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Add Accept header to match backend constraints for the various json:api endpoints
- [x] Fixed tests to use a local backend for integration testing - these will be mocked later
- [x] Moved to disabling circle ci for now since we have no means of mocking a backend that only defines internal routes

### Why?

We historically have always communicated with the backend via the
frontend application.

Ruby makes for an inefficient reverse proxy and we can actually speak
directly via the internal routes between the applications.

NB: I've disabled the CI for the moment since we no longer have public
routes available for the tests to speak to the application (the api
implementation between the backend and the frontend is slightly
different)
