### PR TITLE
Adds public option to Uktt::Http builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ jobs:
           COVERAGE: 1
     steps:
       - checkout
-      # - ruby/install-deps
-      # - ruby/rspec-test
+      - ruby/install-deps
+      - ruby/rspec-test
 
 workflows:
   version: 2

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in uktt.gemspec
 gemspec
-
-gem 'retriable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uktt (2.1.0)
+    uktt (2.2.0)
       retriable
 
 GEM
@@ -96,7 +96,6 @@ DEPENDENCIES
   json-schema
   pry-byebug
   rake
-  retriable
   rspec
   rspec_junit_formatter
   rubocop-govuk

--- a/lib/uktt/version.rb
+++ b/lib/uktt/version.rb
@@ -1,3 +1,3 @@
 module Uktt
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.2.0'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,11 +4,12 @@ require 'pry'
 require 'uktt'
 
 RSpec.shared_context 'with http resources' do
-  let(:http) { Uktt::Http.build(host, version, format) }
+  let(:http) { Uktt::Http.build(host, version, format, public_routes) }
 
-  let(:host) { 'http://localhost:3000/' }
+  let(:host) { 'https://dev.trade-tariff.service.gov.uk' }
   let(:version) { 'v2' }
   let(:format) { 'jsonapi' }
+  let(:public_routes) { true }
 end
 
 RSpec.configure do |config|

--- a/spec/uktt/quota_spec.rb
+++ b/spec/uktt/quota_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Uktt::Quota, :http do
         goods_nomenclature_item_id: '0805102200',
         year: '2018',
         geographical_area_id: 'EG',
-        order_number: '091784',
+        order_number: '050006',
         status: 'not_blocked',
       }
     end


### PR DESCRIPTION

### Jira link

https://transformuk.atlassian.net/browse/HOTT-748

### What?

I have added/removed/altered:

- [x] Adds public mode to uktt gem
- [x] Reenable specs to be run on circle ci

### Why?

I am doing this because:

- This enables us to use public routes when rolling the duty calculator in
a docker container or in circle ci integration environments
