### PR TITLE
Fixes issue with filter not working in duty calculator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uktt (2.2.0)
+    uktt (2.2.1)
       retriable
 
 GEM

--- a/lib/uktt/http.rb
+++ b/lib/uktt/http.rb
@@ -17,7 +17,8 @@ module Uktt
 
     def retrieve(resource, query_config = {})
       resource = File.join(service, 'api', version, resource) if public?
-      resource = "/#{resource}#{query_params(query_config)}"
+      resource = File.join('/', resource)
+      resource = "#{resource}#{query_params(query_config)}"
 
       response = Retriable.retriable(intervals: retriable_intervals) do
         do_fetch(resource)

--- a/lib/uktt/version.rb
+++ b/lib/uktt/version.rb
@@ -1,3 +1,3 @@
 module Uktt
-  VERSION = '2.2.0'.freeze
+  VERSION = '2.2.1'.freeze
 end

--- a/spec/uktt/quota_spec.rb
+++ b/spec/uktt/quota_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Uktt::Quota, :http do
         goods_nomenclature_item_id: '0805102200',
         year: '2018',
         geographical_area_id: 'EG',
-        order_number: '050006',
+        order_number: '091784',
         status: 'not_blocked',
       }
     end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-761

### What?

I have added/removed/altered:

- [x] Handle case where we have already prefixed the resource with /
- [x] Adds spec to validate public/non-public resource construction

### Why?

I am doing this because:

- Without this change our resource has more than one / prefix which breaks
filtering by geographical area. We filter by geographical area to return measures
that are applicable to our origin country
