### PR TITLE
Adds the id to the parsed jsonapi response.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uktt (2.3.0)
+    uktt (2.4.0)
       retriable
 
 GEM
@@ -27,7 +27,7 @@ GEM
     method_source (1.0.0)
     minitest (5.14.4)
     parallel (1.20.1)
-    parser (3.0.1.1)
+    parser (3.0.2.0)
       ast (~> 2.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -38,7 +38,7 @@ GEM
     public_suffix (4.0.6)
     rack (2.2.3)
     rainbow (3.0.0)
-    rake (13.0.3)
+    rake (13.0.6)
     regexp_parser (2.1.1)
     retriable (3.1.2)
     rexml (3.2.5)

--- a/lib/uktt/parser/json_api.rb
+++ b/lib/uktt/parser/json_api.rb
@@ -43,6 +43,7 @@ module Uktt
       end
 
       def parse_top_level_attributes!(attributes, parent)
+        parent['id'] = attributes['id']
         parent.merge!(attributes['attributes'])
       end
 

--- a/lib/uktt/version.rb
+++ b/lib/uktt/version.rb
@@ -1,3 +1,3 @@
 module Uktt
-  VERSION = '2.3.0'.freeze
+  VERSION = '2.4.0'.freeze
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds id resources that define them properly. It's worth noting that the default (incorrect) behaviour of our apis - where the id is defined on the attributes - won't break since we merge them after we're done merging the compliant ids.

### Why?

I am doing this because:

- We have a bunch of non-compliant jsonapi serializers with add the id to the attributes section of the resource. We want to make sure that the resource serializers that actually are compliant are having their ids extracted from the right place - rather than having no id value.
