### PR TITLE
Adds faraday with net-http-persistent adapter to uktt gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,11 @@
 PATH
   remote: .
   specs:
-    uktt (2.4.0)
-      retriable
+    uktt (2.5.0)
+      faraday
+      faraday-net_http_persistent
+      faraday_middleware
+      net-http-persistent
 
 GEM
   remote: https://rubygems.org/
@@ -19,13 +22,38 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
     diff-lcs (1.4.4)
+    faraday (1.7.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday_middleware (1.1.0)
+      faraday (~> 1.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
     method_source (1.0.0)
     minitest (5.14.4)
+    multipart-post (2.1.1)
+    net-http-persistent (4.0.1)
+      connection_pool (~> 2.2)
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -40,7 +68,6 @@ GEM
     rainbow (3.0.0)
     rake (13.0.6)
     regexp_parser (2.1.1)
-    retriable (3.1.2)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -84,6 +111,7 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)

--- a/lib/uktt/http.rb
+++ b/lib/uktt/http.rb
@@ -7,7 +7,7 @@ module Uktt
     DEFAULT_PARSED_FORMAT = 'jsonapi'.freeze
     DEFAULT_RETRIABLE_OPTIONS = {
       max: 2,
-      interval: 0.05,
+      interval: 2.0,
       interval_randomness: 0.5,
       backoff_factor: 2,
     }.freeze
@@ -29,6 +29,7 @@ module Uktt
     def self.build(host, version, format, public_routes, retriable_options = nil)
       connection = Faraday.new(url: host) do |faraday|
         faraday.use FaradayMiddleware::FollowRedirects
+        faraday.use Faraday::Response::RaiseError
         faraday.adapter :net_http_persistent
         faraday.response :logger if ENV['DEBUG_REQUESTS']
       end

--- a/lib/uktt/http.rb
+++ b/lib/uktt/http.rb
@@ -1,12 +1,16 @@
-require 'net/http'
-require 'uri'
-require 'retriable'
+require 'faraday'
+require 'faraday_middleware'
 
 module Uktt
   class Http
     DEFAULT_BACKEND_SERVICE = 'uk'.freeze
     DEFAULT_PARSED_FORMAT = 'jsonapi'.freeze
-    DEFAULT_RETRIABLE_INTERVALS = [0.5, 1.0, 2.0, 2.5, 20.0].freeze
+    DEFAULT_RETRIABLE_OPTIONS = {
+      max: 2,
+      interval: 0.05,
+      interval_randomness: 0.5,
+      backoff_factor: 2,
+    }.freeze
     DEFAULT_VERSION = 'v2'.freeze
     DEFAULT_PUBLIC_MODE = false
 
@@ -16,26 +20,23 @@ module Uktt
     end
 
     def retrieve(resource, query_config = {})
-      resource = File.join(service, 'api', version, resource) if public?
-      resource = File.join('/', resource)
-      resource = "#{resource}#{query_params(query_config)}"
-
-      response = Retriable.retriable(intervals: retriable_intervals) do
-        do_fetch(resource)
-      end
+      resource = File.join(host, 'api', version, resource) if public?
+      response = do_fetch(resource, query_config)
 
       Parser.new(response.body, format).parse
     end
 
-    def self.build(host, version, format, public_routes, retriable_intervals = nil)
-      uri = URI(host)
-      connection = Net::HTTP.new(uri.host, uri.port)
-      connection.use_ssl = uri.scheme.include?('https')
+    def self.build(host, version, format, public_routes, retriable_options = nil)
+      connection = Faraday.new(url: host) do |faraday|
+        faraday.use FaradayMiddleware::FollowRedirects
+        faraday.adapter :net_http_persistent
+        faraday.response :logger if ENV['DEBUG_REQUESTS']
+      end
 
       options = {
+        host: host,
         format: format,
-        retriable_intervals: retriable_intervals,
-        service: uri.path,
+        retriable_options: retriable_options,
         public: public_routes,
         version: version,
       }
@@ -45,29 +46,19 @@ module Uktt
 
     private
 
-    def do_fetch(resource, redirect_limit = 2)
-      request = Net::HTTP::Get.new(resource)
-      request['Accept'] = "application/vnd.uktt.#{version}"
-      request['Content-Type'] = 'application/json'
-
-      response = @connection.request(request)
-
-      case response
-      when Net::HTTPSuccess     then response
-      when Net::HTTPRedirection then do_fetch(response['location'], redirect_limit - 1)
-      else
-        response.error!
-      end
+    def do_fetch(resource, query_config)
+      @connection.get(resource, query_config, headers)
     end
 
-    def query_params(query_config)
-      return '' if query_config.empty?
+    def headers
+      {
+        'Accept' => "application/vnd.uktt.#{version}",
+        'Content-Type' => 'application/json',
+      }
+    end
 
-      query = query_config.map do |key, value|
-        "#{key}=#{value}"
-      end
-
-      "?#{query.join('&')}"
+    def host
+      @options[:host]
     end
 
     def service
@@ -82,8 +73,8 @@ module Uktt
       @options.fetch(:version, DEFAULT_VERSION)
     end
 
-    def retriable_intervals
-      @options.fetch(:retriable_intervals, DEFAULT_RETRIABLE_INTERVALS)
+    def retriable_options
+      @options.fetch(:retriable_options, DEFAULT_RETRIABLE_OPTIONS)
     end
 
     def public?

--- a/lib/uktt/version.rb
+++ b/lib/uktt/version.rb
@@ -1,3 +1,3 @@
 module Uktt
-  VERSION = '2.4.0'.freeze
+  VERSION = '2.5.0'.freeze
 end

--- a/uktt.gemspec
+++ b/uktt.gemspec
@@ -19,7 +19,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w[lib]
   spec.required_ruby_version = '>= 2.7.4'
 
-  spec.add_dependency 'retriable'
+  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday_middleware'
+  spec.add_dependency 'faraday-net_http_persistent'
+  spec.add_dependency 'net-http-persistent'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'json-schema'


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-882

### What?

I have added/removed/altered:

- [x] Added faraday to the uktt gem
- [x] Updated tests to reflect change in adapter

### Why?

I am doing this because:

- This is desired as part of debugging why connections can be a bit buggy on high loads in production

### AC

- [x] Supports retriable functionality
- [x] Supports redirects
- [x] Supports more efficient adapter
- [x] Does not change api of gem
- [x] Tested in private routes mode
