### PR TITLE
HOTT-1382: Support fetching rules of origin schemes

### DIFF
--- a/lib/uktt/resources/rules_of_origin_scheme.rb
+++ b/lib/uktt/resources/rules_of_origin_scheme.rb
@@ -1,0 +1,5 @@
+module Uktt
+  class RulesOfOriginScheme < Base
+    RESOURCE_PATH = 'rules_of_origin_schemes'.freeze
+  end
+end

--- a/spec/uktt/rules_of_origin_scheme_spec.rb
+++ b/spec/uktt/rules_of_origin_scheme_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Uktt::RulesOfOriginScheme, :http do
+  subject(:rules_of_origin_scheme) { described_class.new(http) }
+
+  let(:http) { instance_double('Uktt::Http') }
+
+  describe '#retrieve_all' do
+    it 'performs a retrieve of countries' do
+      allow(http).to receive(:retrieve).with('rules_of_origin_schemes.json', heading_code: '050100', country_code: 'RO')
+
+      rules_of_origin_scheme.retrieve_all(heading_code: '050100', country_code: 'RO')
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1382

### What?

I have added/removed/altered:

- [x] Added support for fetching rules of origin schemes

### Why?

I am doing this because:

- This is required so the duty calculator can fetch the schemes which pertain to the rules of origin
