### PR TITLE
Fixed support for join entities

### DIFF
--- a/spec/fixtures/multiple_invalid_relationship.json
+++ b/spec/fixtures/multiple_invalid_relationship.json
@@ -1,0 +1,28 @@
+{
+  "data" : [
+    {
+      "meta": { "foo": "bar" },
+      "id": "123",
+      "type": "mock_entity",
+      "attributes": {
+        "name": "Joe",
+        "age": 21
+      },
+      "relationships": {
+        "parts": {
+          "data": [null]
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "meta": { "foo": "bar" },
+      "id": 456,
+      "type": "part",
+      "attributes": {
+        "part_name": "A part name"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/multiple_missing_relationship.json
+++ b/spec/fixtures/multiple_missing_relationship.json
@@ -1,0 +1,24 @@
+{
+  "data" : [
+    {
+      "meta": { "foo": "bar" },
+      "id": "123",
+      "type": "mock_entity",
+      "attributes": {
+        "name": "Joe",
+        "age": 21
+      },
+      "relationships": {
+        "parts": {
+          "data": [
+            {
+              "id": 456,
+              "type": "part"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "included": []
+}

--- a/spec/fixtures/multiple_no_relationship.json
+++ b/spec/fixtures/multiple_no_relationship.json
@@ -1,0 +1,14 @@
+{
+  "data": [
+    {
+      "meta": { "foo": "bar" },
+      "id": "123",
+      "type": "mock_entity",
+      "attributes": {
+        "name": "Joe",
+        "age": 21
+      }
+    }
+  ],
+  "included": []
+}

--- a/spec/fixtures/multiple_with_relationship.json
+++ b/spec/fixtures/multiple_with_relationship.json
@@ -1,0 +1,33 @@
+{
+  "data": [
+    {
+      "meta": { "foo": "bar" },
+      "id": "123",
+      "type": "mock_entity",
+      "attributes": {
+        "name": "Joe",
+        "age": 21
+      },
+      "relationships": {
+        "parts": {
+          "data": [
+            {
+              "id": 456,
+              "type": "part"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "meta": { "foo": "bar" },
+      "id": 456,
+      "type": "part",
+      "attributes": {
+        "part_name": "A part name"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/singular_invalid_relationship.json
+++ b/spec/fixtures/singular_invalid_relationship.json
@@ -1,0 +1,26 @@
+{
+  "data" : {
+    "meta": { "foo": "bar" },
+    "id": "123",
+    "type": "mock_entity",
+    "attributes": {
+      "name": "Joe",
+      "age": 21
+    },
+    "relationships": {
+      "parts": {
+        "data": [null]
+      }
+    }
+  },
+  "included": [
+    {
+      "meta": { "foo": "bar" },
+      "id": 456,
+      "type": "part",
+      "attributes": {
+        "part_name": "A part name"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/singular_missing_relationship.json
+++ b/spec/fixtures/singular_missing_relationship.json
@@ -1,0 +1,22 @@
+{
+  "data" : {
+    "meta": { "foo": "bar" },
+    "id": "123",
+    "type": "mock_entity",
+    "attributes": {
+      "name": "Joe",
+      "age": 21
+    },
+    "relationships": {
+      "parts": {
+        "data": [
+          {
+            "id": 456,
+            "type": "part"
+          }
+        ]
+      }
+    }
+  },
+  "included": []
+}

--- a/spec/fixtures/singular_no_attributes.json
+++ b/spec/fixtures/singular_no_attributes.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "meta": { "foo": "bar" },
+    "id": "123",
+    "type": "mock_entity"
+  },
+  "included": []
+}

--- a/spec/fixtures/singular_no_relationship.json
+++ b/spec/fixtures/singular_no_relationship.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "meta": { "foo": "bar" },
+    "id": "123",
+    "type": "mock_entity",
+    "attributes": {
+      "name": "Joe",
+      "age": 21
+    }
+  },
+  "included": []
+}

--- a/spec/fixtures/singular_valid_null_singular_relationship.json
+++ b/spec/fixtures/singular_valid_null_singular_relationship.json
@@ -1,0 +1,17 @@
+{
+  "data" : {
+    "meta": { "foo": "bar" },
+    "id": "123",
+    "type": "mock_entity",
+    "attributes": {
+      "name": "Joe",
+      "age": 21
+    },
+    "relationships": {
+      "part": {
+        "data": null
+      }
+    }
+  },
+  "included": []
+}

--- a/spec/fixtures/singular_with_relationship.json
+++ b/spec/fixtures/singular_with_relationship.json
@@ -1,0 +1,31 @@
+{
+  "data" : {
+    "meta": { "foo": "bar" },
+    "id": "123",
+    "type": "mock_entity",
+    "attributes": {
+      "name": "Joe",
+      "age": 21
+    },
+    "relationships": {
+      "parts": {
+        "data": [
+          {
+            "id": 456,
+            "type": "part"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "meta": { "foo": "bar" },
+      "id": 456,
+      "type": "part",
+      "attributes": {
+        "part_name": "A part name"
+      }
+    }
+  ]
+}

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe Uktt::Parser do
   subject(:parser) { described_class.new(body, format) }
 
-  let(:body) { read_file('commodity.json') }
+  let(:body) { read_file("#{json_file}.json") }
+  let(:json_file) { 'commodity' }
 
   context 'when parsing to ostruct' do
     let(:format) { 'ostruct' }
@@ -35,6 +36,106 @@ RSpec.describe Uktt::Parser do
 
     it 'propagates an error' do
       expect { parser.parse }.to raise_error(ArgumentError, 'Specified invalid format foo')
+    end
+  end
+
+  context 'with singular resource' do
+    subject(:parsed) { parser.parse }
+
+    let(:format) { 'jsonapi' }
+
+    context 'with valid' do
+      let(:json_file) { 'singular_no_relationship' }
+
+      it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
+      it { is_expected.to include 'name' => 'Joe' }
+      it { is_expected.to include 'age' => 21 }
+    end
+
+    context 'without attributes field' do
+      let(:json_file) { 'singular_no_attributes' }
+
+      it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
+      it { is_expected.not_to include 'name' }
+    end
+
+    context 'with relationships' do
+      let(:json_file) { 'singular_with_relationship' }
+
+      it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
+      it { is_expected.to include 'name' => 'Joe' }
+      it { is_expected.to include 'age' => 21 }
+      it { is_expected.to include 'parts' => [{ 'id' => 456, 'meta' => { 'foo' => 'bar' }, 'part_name' => 'A part name' }] }
+    end
+
+    context 'with valid missing relationship' do
+      let(:json_file) { 'singular_valid_null_singular_relationship' }
+
+      it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
+      it { is_expected.to include 'name' => 'Joe' }
+      it { is_expected.to include 'age' => 21 }
+      it { is_expected.to include 'part' => nil }
+    end
+
+    context 'with missing relationships' do
+      let(:json_file) { 'singular_missing_relationship' }
+
+      it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
+      it { is_expected.to include 'name' => 'Joe' }
+      it { is_expected.to include 'age' => 21 }
+      it { is_expected.to include 'parts' => [{}] }
+    end
+
+    context 'with invalid relationships' do
+      let(:json_file) { 'singular_invalid_relationship' }
+
+      it 'raises a description exception' do
+        expect { parsed }.to raise_exception \
+          described_class::JsonApi::ParsingError,
+          "Error finding relationship 'parts': nil"
+      end
+    end
+  end
+
+  context 'with array resource' do
+    subject(:parsed) { parser.parse.first }
+
+    let(:format) { 'jsonapi' }
+
+    context 'with valid' do
+      let(:json_file) { 'multiple_no_relationship' }
+
+      it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
+      it { is_expected.to include 'name' => 'Joe' }
+      it { is_expected.to include 'age' => 21 }
+    end
+
+    context 'with relationships' do
+      let(:json_file) { 'multiple_with_relationship' }
+
+      it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
+      it { is_expected.to include 'name' => 'Joe' }
+      it { is_expected.to include 'age' => 21 }
+      it { is_expected.to include 'parts' => [{ 'id' => 456, 'meta' => { 'foo' => 'bar' }, 'part_name' => 'A part name' }] }
+    end
+
+    context 'with missing relationships' do
+      let(:json_file) { 'multiple_missing_relationship' }
+
+      it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
+      it { is_expected.to include 'name' => 'Joe' }
+      it { is_expected.to include 'age' => 21 }
+      it { is_expected.to include 'parts' => [{}] }
+    end
+
+    context 'with invalid relationships' do
+      let(:json_file) { 'multiple_invalid_relationship' }
+
+      it 'raises a description exception' do
+        expect { parsed }.to raise_exception \
+          described_class::JsonApi::ParsingError,
+          "Error finding relationship 'parts': nil"
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,9 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
   config.include_context 'with http resources', :http
 
   config.expect_with :rspec do |c|


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Added support for parsing join entities (ie entities which only provide relationships between other entities but no attributes of their own
- [x] Extended the jsonapi parser specs
- [x] Added error handling when receiving unexpected jsonapi format content

### Why?

I am doing this because:

- The permutations additions to the commodities endpoint cannot currently be parsed by this gem, preventing enabling of that feature

