### PR TITLE
HOTT-1909: Adds basic auth support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 orbs:
-  ruby: circleci/ruby@1.1.2
+  ruby: circleci/ruby@1
 
 jobs:
   checking:
     docker:
-      - image: 'cimg/ruby:3.1.1'
+      - image: cimg/ruby:3.1.2
     steps:
       - checkout
       - ruby/install-deps
@@ -15,12 +15,7 @@ jobs:
           label: Inspecting with Rubocop
   test:
     docker:
-      - image: cimg/ruby:3.1.1
-        environment:
-          BUNDLE_JOBS: "3"
-          BUNDLE_RETRY: "3"
-          RAILS_ENV: test
-          COVERAGE: 1
+      - image: cimg/ruby:3.1.2
     steps:
       - checkout
       - ruby/install-deps
@@ -31,6 +26,4 @@ workflows:
   build_and_test:
     jobs:
       - checking
-      - test:
-          requires:
-            - checking
+      - test

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ vendor/
 *.gem
 
 .nvimlog
+
+.env

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uktt (2.5.0)
+    uktt (2.6.0)
       faraday
       faraday-net_http_persistent
       faraday_middleware
@@ -23,7 +23,8 @@ GEM
     concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
     diff-lcs (1.5.0)
-    faraday (1.10.0)
+    dotenv (2.8.1)
+    faraday (1.10.2)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -39,8 +40,8 @@ GEM
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.3)
-      multipart-post (>= 1.2, < 3)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
@@ -54,7 +55,7 @@ GEM
       addressable (>= 2.4)
     method_source (1.0.0)
     minitest (5.15.0)
-    multipart-post (2.1.1)
+    multipart-post (2.2.3)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     parallel (1.21.0)
@@ -123,6 +124,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
+  dotenv
   json-schema
   pry-byebug
   rake

--- a/lib/uktt/http.rb
+++ b/lib/uktt/http.rb
@@ -93,6 +93,5 @@ module Uktt
     def public?
       @options.fetch(:public, DEFAULT_PUBLIC_MODE)
     end
-
   end
 end

--- a/lib/uktt/http.rb
+++ b/lib/uktt/http.rb
@@ -17,7 +17,6 @@ module Uktt
     def initialize(connection, options)
       @connection = connection
       @options = options
-      Dotenv.load
     end
 
     def retrieve(resource, query_config = {})

--- a/lib/uktt/http.rb
+++ b/lib/uktt/http.rb
@@ -17,6 +17,7 @@ module Uktt
     def initialize(connection, options)
       @connection = connection
       @options = options
+      Dotenv.load
     end
 
     def retrieve(resource, query_config = {})
@@ -26,23 +27,38 @@ module Uktt
       Parser.new(response.body, format).parse
     end
 
-    def self.build(host, version, format, public_routes, retry_options = nil)
-      connection = Faraday.new(url: host) do |faraday|
-        faraday.use FaradayMiddleware::FollowRedirects
-        faraday.use Faraday::Response::RaiseError
-        faraday.response :logger if ENV['DEBUG_REQUESTS']
-        faraday.request :retry, retry_options || DEFAULT_RETRY_OPTIONS
-        faraday.adapter :net_http_persistent
+    class << self
+      def build(host, version, format, public_routes, retry_options = nil)
+        connection = Faraday.new(url: host) do |faraday|
+          faraday.use FaradayMiddleware::FollowRedirects
+          faraday.use Faraday::Response::RaiseError
+          faraday.response :logger if ENV['DEBUG_REQUESTS']
+          faraday.request :basic_auth, basic_username, basic_password if basic_auth?
+          faraday.request :retry, retry_options || DEFAULT_RETRY_OPTIONS
+          faraday.adapter :net_http_persistent
+        end
+
+        options = {
+          host:,
+          format:,
+          public: public_routes,
+          version:,
+        }
+
+        new(connection, options)
       end
 
-      options = {
-        host:,
-        format:,
-        public: public_routes,
-        version:,
-      }
+      def basic_auth?
+        ENV['BASIC_AUTH'] == 'true'
+      end
 
-      new(connection, options)
+      def basic_username
+        ENV['BASIC_USERNAME']
+      end
+
+      def basic_password
+        ENV['BASIC_PASSWORD']
+      end
     end
 
     private
@@ -77,5 +93,6 @@ module Uktt
     def public?
       @options.fetch(:public, DEFAULT_PUBLIC_MODE)
     end
+
   end
 end

--- a/lib/uktt/version.rb
+++ b/lib/uktt/version.rb
@@ -1,3 +1,3 @@
 module Uktt
-  VERSION = '2.5.0'.freeze
+  VERSION = '2.6.0'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'bundler/setup'
+require 'dotenv/load'
 require 'json-schema'
 require 'pry'
 require 'uktt'

--- a/uktt.gemspec
+++ b/uktt.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'net-http-persistent'
 
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'json-schema'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1909

### What?

I have added/removed/altered:

- [x] Adds .env file to .gitignore
- [x] Adds bkeepers/dotenv to dev deps
- [x] Load .env when running specs
- [x] Adds conditional support for basic auth to http client
- [x] Increment version

### Why?

I am doing this because:

- This is required to enable local development ci tests to pass against the staging/development envs
