### PR TITLE
BAU: Use writeShellScriptBin for explicit bash shebang in flake scripts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
         rubyVersion = builtins.head (builtins.split "\n" (builtins.readFile ./.ruby-version));
         ruby = pkgs."ruby-${rubyVersion}";
 
-        lint = pkgs.writeScriptBin "lint" ''
+        lint = pkgs.writeShellScriptBin "lint" ''
           changed_files=$(git diff --name-only --diff-filter=ACM --merge-base main)
 
           bundle exec rubocop --autocorrect-all --force-exclusion $changed_files Gemfile


### PR DESCRIPTION
### What?

- [x] Replace `writeScriptBin` with `writeShellScriptBin` for all helper scripts in flake.nix

### Why?

`writeScriptBin` does not add a shebang line, so scripts rely on the system default interpreter. On macOS this may not be bash, causing scripts to fail or behave unexpectedly. `writeShellScriptBin` uses Nix's bash with an explicit shebang.