### PR TITLE
Add gem-update-bot workflow

### DIFF
--- a/.github/workflows/gem-update-bot.yml
+++ b/.github/workflows/gem-update-bot.yml
@@ -1,0 +1,46 @@
+name: Gem Update Bot
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * 1'
+
+jobs:
+  gem-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0.3'
+          bundler-cache: true
+
+      - name: Update gems
+        run: bundle update --jobs=4 --retry=3
+
+      - name: Create PR
+        run: |
+          BRANCH="gem-update-$(date +%Y%m%d)"
+          git config user.name "hermes-agent[bot]"
+          git config user.email "hermes-agent[bot]@users.noreply.github.com"
+          
+          if git diff --quiet Gemfile.lock 2>/dev/null; then
+            echo "No changes"
+            exit 0
+          fi
+          
+          git checkout -b "$BRANCH"
+          git add Gemfile.lock
+          git commit -m "Update Gemfile.lock"
+          git push -u origin "$BRANCH"
+          
+          gh pr create \
+            --title "Update Gemfile.lock" \
+            --body "**Risk level:** 🟢 Green — Dependency bumps with no API changes (minor/patch gems)" \
+            --label "dependencies"


### PR DESCRIPTION
## What:
Adds a GitHub Actions workflow (`gem-update-bot.yml`) that:
- Runs on a weekly schedule (Monday 08:00 UTC) and can be triggered manually via `workflow_dispatch`
- Updates gems via `bundle update`
- Creates a PR with the updated `Gemfile.lock`

## Why:
Automated gem updates ensure dependencies stay current without manual effort, producing reviewable PRs rather than auto-merged updates.

## Ticket:
N/A — maintenance automation

## Risk:
**Risk level:** 🟢 Green
**Reason for rating:** Adds an internal CI workflow; PRs it creates require normal team review before merging.
